### PR TITLE
Hardcoded API specification URL

### DIFF
--- a/.github/workflows/autogenerate_api_client.yaml
+++ b/.github/workflows/autogenerate_api_client.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Generate API Client
         run: |
-          bash autogenerate_api_client.sh ${{github.event.inputs.endpoint}}
+          bash autogenerate_api_client.sh https://raw.githubusercontent.com/TaskarCenterAtUW/TDEI-ExternalAPIs/gs-api-gateway-implementation/tdei-api-gateway.json
           
 
       - name: Run Bash Script


### PR DESCRIPTION
As long as we are using this, we can hardcode it for the time being. Until 466 is tested. 
Then I will check how to pass it as a parameter