### PR TITLE
removing dist from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 wwwroot/*.js
 node_modules
 typings
-dist


### PR DESCRIPTION
removing dist from gitignore , dist is required for api-tester 